### PR TITLE
Fix pink hover highlight on experience timeline dot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,9 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Claude Code local tooling config
+.claude/
+
+# macOS
+.DS_Store

--- a/components/Experience.js
+++ b/components/Experience.js
@@ -170,8 +170,9 @@ const Dot = styled.div`
     }
 
     ${TimelineItem}:hover & {
-        background: ${({ theme }) => theme.colors.primary};
-        box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.primary};
+        background: #111111;
+        box-shadow: 0 0 0 2px #111111;
+        transform: scale(1.15);
     }
 `
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  compiler: {
+    styledComponents: true,
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
The timeline dot's hover state used theme.colors.primary, which is set to pink, causing a jarring highlight (and a "stuck" look on touch-scroll devices) in the experience section.